### PR TITLE
added default timeout of 5 seconds to azure_insights http requests

### DIFF
--- a/include/erlazure.hrl
+++ b/include/erlazure.hrl
@@ -63,7 +63,7 @@
 -endif.
 
 -record(azure_config,
-    {auth_token="" :: string()}
+    {auth_token="" :: string(), http_timeout=5000}
 ).
 
 %% Types

--- a/src/erlazure_insights.erl
+++ b/src/erlazure_insights.erl
@@ -57,7 +57,7 @@ follow_token(Url, DataAcc, Config) ->
     end.
 
 request_api(Url, Config) ->
-    Response = httpc:request(get, {Url, construct_headers(Config)}, [], []),
+    Response = httpc:request(get, {Url, construct_headers(Config)}, [{timeout, Config#azure_config.http_timeout}], []),
 
     case Response of
         {ok, {{_Version, 200, _Phrase}, _Headers, Body}} ->


### PR DESCRIPTION
### Problem

There is currently no timeout time specified for erlazure_insights http requests
### Solution

Added default timeout of 5000ms (5 seconds) to azure_config record and pass that value to httpc http_options() parameter (see http://erlang.org/doc/man/httpc.html#request-1 for configuration docs)
